### PR TITLE
Replace python random.choice with tf operations

### DIFF
--- a/datasets/augmentation_factory.py
+++ b/datasets/augmentation_factory.py
@@ -1,4 +1,3 @@
-import random
 from tensorflow.contrib.framework.python.ops import audio_ops as contrib_audio
 import tensorflow as tf
 
@@ -20,8 +19,8 @@ def no_augmentation(x):
     return x
 
 
-def _gen_random_from_zero(maxval):
-    return tf.random.uniform([], maxval=maxval)
+def _gen_random_from_zero(maxval, dtype=tf.float32):
+    return tf.random.uniform([], maxval=maxval, dtype=dtype)
 
 
 def _gen_empty_audio(desired_samples):
@@ -56,7 +55,15 @@ def _mix_background(
     )
 
     # sampling background
-    background_wav = random.choice(background_data)
+    random_background_data_idx = _gen_random_from_zero(
+        len(background_data),
+        dtype=tf.int32
+    )
+    background_wav = tf.case({
+        tf.equal(background_data_idx, random_background_data_idx): 
+            lambda tensor=wav: tensor
+        for background_data_idx, wav in enumerate(background_data)
+    }, exclusive=True)
     background_wav = tf.random_crop(background_wav, [desired_samples, 1])
 
     if naive_version:


### PR DESCRIPTION
Python `random.choice` will be evaluated only once. 

We can use `tf.case`, which will read all the background wavs, to randomly select a loaded background wav from the six `_background_noise_` wavs in Speech Command Dataset (v0.01).

The following code (tested with `tensorflow` 1.13.1) reproduces the issue:

```python
import random

import tensorflow as tf


num_audios = 10
audio_dataset = tf.data.Dataset.from_tensor_slices([0]).repeat(num_audios)
background_data = [tf.constant(data) for data in range(6)]

python_random_choice_dataset = audio_dataset.map(
    lambda audio: audio + random.choice(background_data))
python_random_choice_output = (
    python_random_choice_dataset.make_one_shot_iterator().get_next()
)
# [4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
print([sess.run(python_random_choice_output) for _ in range(num_audios)])

def tf_case_mix_background(audio):
    random_index = tf.random.uniform([], maxval=len(background_data),
                                     dtype=tf.int32)
    background_wav = tf.case({
        tf.equal(index, random_index): lambda tensor=data: tensor
        for index, data in enumerate(background_data)
    }, exclusive=True)
    return audio + background_wav

tf_case_dataset = audio_dataset.map(tf_case_mix_background)
tf_case_output = tf_case_dataset.make_one_shot_iterator().get_next()
# [3, 2, 1, 3, 2, 5, 3, 0, 2, 4]
print([sess.run(tf_case_output) for _ in range(num_audios)])
```

Note that when the number of background wavs is large, we may create a `tf.data.Dataset` to randomly load the background wavs and use `tf.data.Dataset.zip((audio_dataset, background_wav_dataset)).map(mix_background_fn)` to generate noisy data.